### PR TITLE
Fix misnamed exception and remove typed constants

### DIFF
--- a/src/Exceptions/ApiEndpointException.php
+++ b/src/Exceptions/ApiEndpointException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ApiEndpointException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API request failed (endpoint): %s';
+    public const EXCEPTION_MESSAGE = 'API request failed (endpoint): %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ApiForbiddenException.php
+++ b/src/Exceptions/ApiForbiddenException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ApiForbiddenException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API request failed (forbidden): %s';
+    public const EXCEPTION_MESSAGE = 'API request failed (forbidden): %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ApiInternalServerException.php
+++ b/src/Exceptions/ApiInternalServerException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ApiInternalServerException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API request failed (internal server): %s';
+    public const EXCEPTION_MESSAGE = 'API request failed (internal server): %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ApiTimeoutException.php
+++ b/src/Exceptions/ApiTimeoutException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ApiTimeoutException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API request failed (request throttling timeout): %s';
+    public const EXCEPTION_MESSAGE = 'API request failed (request throttling timeout): %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ApiTransactionException.php
+++ b/src/Exceptions/ApiTransactionException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ApiTransactionException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API request failed (transaction): %s';
+    public const EXCEPTION_MESSAGE = 'API request failed (transaction): %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ApiUnauthenticatedException.php
+++ b/src/Exceptions/ApiUnauthenticatedException.php
@@ -8,9 +8,9 @@ use Exception;
 
 use function sprintf;
 
-final class ApiUnuthenticatedException extends Exception
+final class ApiUnauthenticatedException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API request failed (unauthenticated): %s';
+    public const EXCEPTION_MESSAGE = 'API request failed (unauthenticated): %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ApiUnexpectedResponseException.php
+++ b/src/Exceptions/ApiUnexpectedResponseException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ApiUnexpectedResponseException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API response was unexpected and unprocessable: %s';
+    public const EXCEPTION_MESSAGE = 'API response was unexpected and unprocessable: %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ApiValidationException.php
+++ b/src/Exceptions/ApiValidationException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ApiValidationException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'API request failed (invalid): %s';
+    public const EXCEPTION_MESSAGE = 'API request failed (invalid): %s';
 
     public function __construct(string $message)
     {

--- a/src/Exceptions/ClientSerializationException.php
+++ b/src/Exceptions/ClientSerializationException.php
@@ -10,7 +10,7 @@ use function sprintf;
 
 final class ClientSerializationException extends Exception
 {
-    public const string EXCEPTION_MESSAGE = 'Serialization of client request body failed: %s';
+    public const EXCEPTION_MESSAGE = 'Serialization of client request body failed: %s';
 
     public function __construct(string $message)
     {

--- a/src/Responses/ResponseTrait.php
+++ b/src/Responses/ResponseTrait.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace OpenFGA\Responses;
 
 use Exception;
-use OpenFGA\Exceptions\{ApiEndpointException, ApiForbiddenException, ApiInternalServerException, ApiTimeoutException, ApiTransactionException, ApiUnuthenticatedException, ApiValidationException};
+use OpenFGA\Exceptions\{ApiEndpointException, ApiForbiddenException, ApiInternalServerException, ApiTimeoutException, ApiTransactionException, ApiUnauthenticatedException, ApiValidationException};
 use Psr\Http\Message\ResponseInterface as HttpResponseInterface;
 
 trait ResponseTrait
@@ -30,7 +30,7 @@ trait ResponseTrait
         }
 
         if (401 === $response->getStatusCode()) {
-            throw new ApiUnuthenticatedException($error);
+            throw new ApiUnauthenticatedException($error);
         }
 
         if (403 === $response->getStatusCode()) {


### PR DESCRIPTION
## Summary
- rename `ApiUnuthenticatedException` to `ApiUnauthenticatedException`
- use the new exception name in `ResponseTrait`
- remove unsupported typed constants from all exception classes

## Testing
- `composer test` *(fails: `composer: command not found`)*