### PR TITLE
ci(test): add docker integration testing

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -28,8 +28,7 @@ jobs:
           tools: composer:v2
 
       - name: Install dependencies
-        run: composer update --prefer-stable --no-interaction --no-progress --ansi
-
+        run: composer install --prefer-dist --no-interaction --no-progress --ansi
       - name: Start OpenFGA
         run: docker compose -f docker-compose.integration.yml up -d
 

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -1,0 +1,38 @@
+name: Integration Tests
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+jobs:
+  integration:
+    name: Run Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden the runner (Audit all outbound calls)
+        uses: step-security/harden-runner@0634a2670c59f64b4a01f0f96f84700a4088b9f0 # v2.12.0
+        with:
+          egress-policy: audit
+
+      - name: Checkout code
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@cf4cade2721270509d5b1c766ab3549210a39a2a # v2
+        with:
+          php-version: '8.3'
+          extensions: dom, curl, libxml, mbstring, zip, fileinfo
+          tools: composer:v2
+
+      - name: Install dependencies
+        run: composer update --prefer-stable --no-interaction --no-progress --ansi
+
+      - name: Start OpenFGA
+        run: docker compose -f docker-compose.integration.yml up -d
+
+      - name: Run integration tests
+        run: composer test:integration
+
+      - name: Stop OpenFGA
+        if: always()
+        run: docker compose -f docker-compose.integration.yml down -v

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, edited]
 
+permissions:
+  contents: read
+
 jobs:
   integration:
     name: Run Integration Tests

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -59,7 +59,7 @@ Unit tests:
 composer test:unit
 ```
 
-Integration tests:
+Integration tests require Docker. The container starts automatically:
 
 ```bash
 composer test:integration

--- a/composer.json
+++ b/composer.json
@@ -86,9 +86,17 @@
       "@putenv XDEBUG_MODE=coverage",
       "@php vendor/bin/pest --colors=always --strict-global-state --fail-on-risky --fail-on-warning --coverage --strict-coverage --compact"
     ],
+    "integration:start": "docker compose -f docker-compose.integration.yml up -d",
+    "integration:stop": "docker compose -f docker-compose.integration.yml down -v",
     "pest:debug": [
       "@putenv XDEBUG_MODE=coverage",
       "@php vendor/bin/pest --colors=always --strict-global-state --fail-on-risky --fail-on-warning --coverage --strict-coverage"
+    ],
+    "pest:integration": [
+      "@integration:start",
+      "@putenv XDEBUG_MODE=coverage",
+      "@php vendor/bin/pest --colors=always --strict-global-state --fail-on-risky --fail-on-warning --configuration phpunit.integration.xml.dist --coverage --strict-coverage --compact",
+      "@integration:stop"
     ],
     "phpcs": [
       "@putenv PHP_CS_FIXER_IGNORE_ENV=1",

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,0 +1,7 @@
+version: '3.8'
+services:
+  openfga:
+    image: openfga/openfga:latest
+    command: run
+    ports:
+      - "8080:8080"

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -5,3 +5,9 @@ services:
     command: run
     ports:
       - "8080:8080"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8080/healthz"]
+      interval: 5s
+      timeout: 3s
+      retries: 3
+      start_period: 5s

--- a/phpunit.integration.xml.dist
+++ b/phpunit.integration.xml.dist
@@ -1,0 +1,22 @@
+<?xml version="1.0"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.1/phpunit.xsd">
+  <coverage>
+    <report>
+      <clover outputFile="coverage/clover.xml"/>
+      <cobertura outputFile="coverage/cobertura.xml"/>
+    </report>
+  </coverage>
+  <testsuites>
+    <testsuite name="integration">
+      <directory>tests/Integration</directory>
+    </testsuite>
+  </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">./src/</directory>
+    </include>
+    <exclude>
+      <directory suffix=".php">./src/API/</directory>
+    </exclude>
+  </source>
+</phpunit>

--- a/tests/Integration/StoreManagementTest.php
+++ b/tests/Integration/StoreManagementTest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+use OpenFGA\Client;
+
+it('creates and deletes a store', function () {
+    $url = getenv('FGA_API_URL') ?: 'http://localhost:8080';
+    $client = new Client(url: $url);
+
+    $name = 'php-sdk-test-' . bin2hex(random_bytes(5));
+    $response = $client->createStore(name: $name);
+    expect($response->getId())->not()->toBe('');
+
+    $delete = $client->deleteStore(store: $response->getId());
+    expect($delete)->toBeInstanceOf(\OpenFGA\Responses\DeleteStoreResponseInterface::class);
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -8,4 +8,4 @@ use OpenFGA\Tests\TestCase;
 
 require_once implode(DIRECTORY_SEPARATOR, [OPENFGA_TESTS_DIR, '..', 'vendor', 'autoload.php']);
 
-pest()->extend(TestCase::class)->in('Unit');
+pest()->extend(TestCase::class)->in(__DIR__);


### PR DESCRIPTION
## Summary
- enable integration tests with Docker
- automatically manage an OpenFGA container
- add GitHub Actions workflow to run integration suite

## Testing
- `composer lint` *(fails: command not found)*
- `composer test:unit` *(fails: command not found)*
- `composer test:integration` *(fails: command not found)*


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added automated integration testing with Docker-based environment setup.
  - Introduced new Composer scripts to start and stop integration test environments and run integration tests with coverage reporting.
  - Added a sample integration test for store creation and deletion using the OpenFGA PHP client.

- **Documentation**
  - Updated integration test documentation to clarify Docker requirements and automated container management.

- **Tests**
  - Added configuration and test files for running integration tests, including a dedicated PHPUnit configuration and Docker Compose setup.
  - Adjusted test discovery settings to include all tests in the main directory.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->