### PR TITLE
feat: add DSL transformer

### DIFF
--- a/src/Language/DslTransformer.php
+++ b/src/Language/DslTransformer.php
@@ -1,0 +1,165 @@
+<?php
+
+declare(strict_types=1);
+
+namespace OpenFGA\Language;
+
+use OpenFGA\Models\{AuthorizationModel, AuthorizationModelInterface, TypeDefinitionInterface, UsersetInterface};
+use OpenFGA\Models\Collections\{TypeDefinitions, TypeDefinitionRelations, Usersets};
+use OpenFGA\Models\Enums\SchemaVersion;
+use OpenFGA\Schema\SchemaValidator;
+use stdClass;
+
+final class DslTransformer
+{
+    public static function fromDsl(string $dsl, SchemaValidator $validator): AuthorizationModelInterface
+    {
+        $lines = preg_split('/\r?\n/', $dsl);
+        $schemaVersion = SchemaVersion::V1_1;
+        $typeDefinitions = [];
+
+        $currentType = null;
+        $relations = [];
+
+        foreach ($lines as $line) {
+            $line = trim($line);
+            if ($line === '' || str_starts_with($line, '#')) {
+                continue;
+            }
+
+            if ($line === 'model') {
+                continue;
+            }
+
+            if (str_starts_with($line, 'schema')) {
+                $version = trim(substr($line, strlen('schema')));
+                if ($version !== '') {
+                    $schemaVersion = SchemaVersion::from($version);
+                }
+                continue;
+            }
+
+            if (preg_match('/^type\s+(\w+)/', $line, $m)) {
+                if ($currentType !== null) {
+                    $typeDefinitions[] = [
+                        'type' => $currentType,
+                        'relations' => $relations === [] ? null : $relations,
+                    ];
+                    $relations = [];
+                }
+                $currentType = $m[1];
+                continue;
+            }
+
+            if ($line === 'relations') {
+                continue;
+            }
+
+            if (preg_match('/^define\s+(\w+)\s*:\s*(.+)$/', $line, $m)) {
+                $relName = $m[1];
+                $expr = $m[2];
+                $relations[$relName] = self::parseExpression($expr);
+            }
+        }
+
+        if ($currentType !== null) {
+            $typeDefinitions[] = [
+                'type' => $currentType,
+                'relations' => $relations === [] ? null : $relations,
+            ];
+        }
+
+        $data = [
+            'id' => uniqid('model_', true),
+            'schema_version' => $schemaVersion->value,
+            'type_definitions' => $typeDefinitions,
+        ];
+
+        return $validator->validateAndTransform($data, AuthorizationModel::class);
+    }
+
+    public static function toDsl(AuthorizationModelInterface $model): string
+    {
+        $lines = [];
+        $lines[] = 'model';
+        $lines[] = '  schema ' . $model->getSchemaVersion()->value;
+
+        foreach ($model->getTypeDefinitions() as $typeDef) {
+            /** @var TypeDefinitionInterface $typeDef */
+            $lines[] = 'type ' . $typeDef->getType();
+            $relations = $typeDef->getRelations();
+            if ($relations !== null && count($relations) > 0) {
+                $lines[] = '  relations';
+                foreach ($relations as $name => $userset) {
+                    /** @var UsersetInterface $userset */
+                    $lines[] = '    define ' . $name . ': ' . self::renderExpression($userset);
+                }
+            }
+        }
+
+        return implode("\n", $lines);
+    }
+
+    private static function parseExpression(string $expr): array
+    {
+        $terms = array_map('trim', explode('or', $expr));
+        $parsed = array_map([self::class, 'parseTerm'], $terms);
+        if (count($parsed) === 1) {
+            return $parsed[0];
+        }
+
+        return ['union' => $parsed];
+    }
+
+    private static function parseTerm(string $term): array
+    {
+        if ($term === 'self') {
+            return ['direct' => new stdClass()];
+        }
+
+        if (preg_match('/^(\w+)#(\w+)$/', $term, $m)) {
+            return [
+                'computed_userset' => [
+                    'object' => $m[1],
+                    'relation' => $m[2],
+                ],
+            ];
+        }
+
+        return [
+            'computed_userset' => [
+                'relation' => $term,
+            ],
+        ];
+    }
+
+    private static function renderExpression(UsersetInterface $userset): string
+    {
+        if ($userset->getUnion() !== null) {
+            $parts = [];
+            foreach ($userset->getUnion() as $child) {
+                $parts[] = self::renderExpression($child);
+            }
+            return implode(' or ', $parts);
+        }
+
+        if ($userset->getDirect() !== null) {
+            return 'self';
+        }
+
+        if ($userset->getComputedUserset() !== null) {
+            $cu = $userset->getComputedUserset();
+            $object = $cu->getObject();
+            $relation = $cu->getRelation();
+            if ($object === null || $object === '') {
+                return (string) $relation;
+            }
+            if ($relation === null || $relation === '') {
+                return (string) $object;
+            }
+            return $object . '#' . $relation;
+        }
+
+        return 'self';
+    }
+}

--- a/tests/Unit/Language/DslTransformerTest.php
+++ b/tests/Unit/Language/DslTransformerTest.php
@@ -1,0 +1,39 @@
+<?php
+
+use OpenFGA\Language\DslTransformer;
+use OpenFGA\Models\AuthorizationModelInterface;
+use OpenFGA\Schema\SchemaValidator;
+
+it('transforms DSL to model and back', function (): void {
+    $dsl = <<<DSL
+model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: self
+    define writer: user
+DSL;
+
+    $validator = new SchemaValidator();
+
+    // Register schemas used by AuthorizationModel
+    $validator
+        ->registerSchema(\OpenFGA\Models\AuthorizationModel::schema())
+        ->registerSchema(\OpenFGA\Models\Collections\TypeDefinitions::schema())
+        ->registerSchema(\OpenFGA\Models\TypeDefinition::schema())
+        ->registerSchema(\OpenFGA\Models\Collections\TypeDefinitionRelations::schema())
+        ->registerSchema(\OpenFGA\Models\Userset::schema())
+        ->registerSchema(\OpenFGA\Models\Collections\Usersets::schema())
+        ->registerSchema(\OpenFGA\Models\ObjectRelation::schema());
+
+    $model = DslTransformer::fromDsl($dsl, $validator);
+
+    expect($model)->toBeInstanceOf(AuthorizationModelInterface::class);
+    expect($model->getSchemaVersion()->value)->toBe('1.1');
+
+    $resultDsl = DslTransformer::toDsl($model);
+    expect(trim($resultDsl))->toBe(trim($dsl));
+});


### PR DESCRIPTION
## Summary
- add a `DslTransformer` for converting between DSL and JSON Authorization Models
- cover round-trip transformation with a Pest test

## Testing
- `composer test` *(fails: composer not installed)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to convert authorization models between a domain-specific language (DSL) format and internal structured form.
- **Tests**
  - Introduced unit tests to verify accurate transformation between DSL strings and authorization model objects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->