### PR TITLE
feat(tools): enhance documentation generator

### DIFF
--- a/tests/Unit/Docs/DocumentationGeneratorTest.php
+++ b/tests/Unit/Docs/DocumentationGeneratorTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+require_once implode(DIRECTORY_SEPARATOR, [__DIR__, '..', '..', '..', 'tools', 'docs', 'generate-docs.php']);
+
+use ReflectionClass;
+
+test('method signature prints default values using PHP syntax', function (): void {
+    class Dummy {
+        public function foo(string $bar = 'baz', array $data = [1, 2]): void {}
+    }
+
+    $generator = new DocumentationGenerator(__DIR__, __DIR__);
+    $method = (new ReflectionClass(Dummy::class))->getMethod('foo');
+
+    $signatureMethod = (new ReflectionClass(DocumentationGenerator::class))
+        ->getMethod('getMethodSignature');
+    $signatureMethod->setAccessible(true);
+    $signature = $signatureMethod->invoke($generator, $method);
+
+    expect($signature)
+        ->toContain("= 'baz'")
+        ->and($signature)->toContain('array')
+        ->and($signature)->toContain('0 => 1');
+});

--- a/tools/docs/README.md
+++ b/tools/docs/README.md
@@ -26,10 +26,12 @@ This tool generates API documentation from the OpenFGA PHP SDK source code.
 Run the documentation generator:
 
 ```bash
-php generate-docs.php
+php generate-docs.php [--src=path/to/src] [--out=path/to/output] [--clean]
 ```
 
-This will parse all PHP files in the `src/` directory and generate Markdown documentation in the `docs/API/` directory.
+`--src` and `--out` let you override the default source and output folders. The optional `--clean` flag removes the output directory before generating files.
+
+This will parse all PHP files in the `src/` directory and generate Markdown documentation in the `docs/API/` directory by default.
 
 ## Customizing the Output
 


### PR DESCRIPTION
## Summary
- add CLI options and clean handling to docs generator
- use `var_export` for parameter defaults
- prevent side effects when including docs generator
- document new options
- add unit test for signature formatting

## Testing
- `composer test` *(fails: composer not found)*
- `php vendor/bin/pest` *(fails: php not found)*