### PR TITLE
docs: add DSL transformer usage guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,40 +71,6 @@ $detail = $client->getAuthorizationModel($store->getId(), $model->getId());
 
 See [docs/AuthorizationModels.md](docs/AuthorizationModels.md) for more information.
 
-## DSL transformer
-
-```php
-use OpenFGA\Language\DslTransformer;
-use OpenFGA\Schema\SchemaValidator;
-
-$dsl = <<'DSL'
-model
-  schema 1.1
-
-type user
-
-type document
-  relations
-    define viewer: self
-DSL;
-
-$validator = new SchemaValidator();
-$validator
-    ->registerSchema(OpenFGA\Models\AuthorizationModel::schema())
-    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitions::schema())
-    ->registerSchema(OpenFGA\Models\TypeDefinition::schema())
-    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitionRelations::schema())
-    ->registerSchema(OpenFGA\Models\Userset::schema())
-    ->registerSchema(OpenFGA\Models\Collections\Usersets::schema())
-    ->registerSchema(OpenFGA\Models\ObjectRelation::schema());
-
-$model = DslTransformer::fromDsl($dsl, $validator);
-$dslString = DslTransformer::toDsl($model);
-```
-
-See [docs/DslTransformer.md](docs/DslTransformer.md) for more information.
-
-
 ## Relationship tuples
 
 ```php
@@ -161,6 +127,8 @@ See [docs/Assertions.md](docs/Assertions.md) for more information.
 
 ## DSL transformer
 
+Use the DSL transformer to parse a DSL schema string into an authorization model and render it back to a DSL string.
+
 ```php
 use OpenFGA\Language\DslTransformer;
 use OpenFGA\Schema\SchemaValidator;
@@ -194,8 +162,7 @@ See [docs/DslTransformer.md](docs/DslTransformer.md) for more information.
 
 ## Documentation
 
-- API reference is in [docs/API](docs/API).
-- DSL transformer usage is in [docs/DslTransformer.md](docs/DslTransformer.md).
+API reference is in [docs/API](docs/API).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,40 @@ $detail = $client->getAuthorizationModel($store->getId(), $model->getId());
 
 See [docs/AuthorizationModels.md](docs/AuthorizationModels.md) for more information.
 
+## DSL transformer
+
+```php
+use OpenFGA\Language\DslTransformer;
+use OpenFGA\Schema\SchemaValidator;
+
+$dsl = <<'DSL'
+model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: self
+DSL;
+
+$validator = new SchemaValidator();
+$validator
+    ->registerSchema(OpenFGA\Models\AuthorizationModel::schema())
+    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitions::schema())
+    ->registerSchema(OpenFGA\Models\TypeDefinition::schema())
+    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitionRelations::schema())
+    ->registerSchema(OpenFGA\Models\Userset::schema())
+    ->registerSchema(OpenFGA\Models\Collections\Usersets::schema())
+    ->registerSchema(OpenFGA\Models\ObjectRelation::schema());
+
+$model = DslTransformer::fromDsl($dsl, $validator);
+$dslString = DslTransformer::toDsl($model);
+```
+
+See [docs/DslTransformer.md](docs/DslTransformer.md) for more information.
+
+
 ## Relationship tuples
 
 ```php
@@ -128,6 +162,7 @@ See [docs/Assertions.md](docs/Assertions.md) for more information.
 ## Documentation
 
 - API reference is in [docs/API](docs/API).
+- DSL transformer usage is in [docs/DslTransformer.md](docs/DslTransformer.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -71,40 +71,6 @@ $detail = $client->getAuthorizationModel($store->getId(), $model->getId());
 
 See [docs/AuthorizationModels.md](docs/AuthorizationModels.md) for more information.
 
-## DSL transformer
-
-```php
-use OpenFGA\Language\DslTransformer;
-use OpenFGA\Schema\SchemaValidator;
-
-$dsl = <<'DSL'
-model
-  schema 1.1
-
-type user
-
-type document
-  relations
-    define viewer: self
-DSL;
-
-$validator = new SchemaValidator();
-$validator
-    ->registerSchema(OpenFGA\Models\AuthorizationModel::schema())
-    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitions::schema())
-    ->registerSchema(OpenFGA\Models\TypeDefinition::schema())
-    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitionRelations::schema())
-    ->registerSchema(OpenFGA\Models\Userset::schema())
-    ->registerSchema(OpenFGA\Models\Collections\Usersets::schema())
-    ->registerSchema(OpenFGA\Models\ObjectRelation::schema());
-
-$model = DslTransformer::fromDsl($dsl, $validator);
-$dslString = DslTransformer::toDsl($model);
-```
-
-See [docs/DslTransformer.md](docs/DslTransformer.md) for more information.
-
-
 ## Relationship tuples
 
 ```php
@@ -159,10 +125,42 @@ $client->writeAssertions($store->getId(), $model->getId(), $assertions);
 
 See [docs/Assertions.md](docs/Assertions.md) for more information.
 
+## DSL transformer
+
+```php
+use OpenFGA\Language\DslTransformer;
+use OpenFGA\Schema\SchemaValidator;
+
+$dsl = <<'DSL'
+model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: self
+DSL;
+
+$validator = new SchemaValidator();
+$validator
+    ->registerSchema(OpenFGA\Models\AuthorizationModel::schema())
+    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitions::schema())
+    ->registerSchema(OpenFGA\Models\TypeDefinition::schema())
+    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitionRelations::schema())
+    ->registerSchema(OpenFGA\Models\Userset::schema())
+    ->registerSchema(OpenFGA\Models\Collections\Usersets::schema())
+    ->registerSchema(OpenFGA\Models\ObjectRelation::schema());
+
+$model = DslTransformer::fromDsl($dsl, $validator);
+$dslString = DslTransformer::toDsl($model);
+```
+
+See [docs/DslTransformer.md](docs/DslTransformer.md) for more information.
+
 ## Documentation
 
 - API reference is in [docs/API](docs/API).
-- DSL transformer usage is in [docs/DslTransformer.md](docs/DslTransformer.md).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ A high-performance PHP client for [OpenFGA](https://openfga.dev/) and [Auth0 FGA
 composer require evansims/openfga-php
 ```
 
-## Quick start
+## Quick Start
 
 Create a client using a shared key or client credentials. Only the URL is required when no authentication is needed.
 
@@ -46,7 +46,7 @@ $client = new Client(
 );
 ```
 
-## Working with stores
+## Working with Stores
 
 ```php
 $response = $client->createStore('my-store');
@@ -57,7 +57,7 @@ $client->deleteStore($store->getId());
 
 See [docs/Stores.md](docs/Stores.md) for more information.
 
-## Authorization models
+## Authorization Models
 
 ```php
 $models = $client->listAuthorizationModels($store->getId());
@@ -71,7 +71,7 @@ $detail = $client->getAuthorizationModel($store->getId(), $model->getId());
 
 See [docs/AuthorizationModels.md](docs/AuthorizationModels.md) for more information.
 
-## Relationship tuples
+## Relationship Tuples
 
 ```php
 $client->writeTuples(
@@ -86,7 +86,7 @@ $changes = $client->listTupleChanges($store->getId());
 
 See [docs/RelationshipTuples.md](docs/RelationshipTuples.md) for more information.
 
-## Relationship queries
+## Relationship Queries
 
 ```php
 $check = $client->check(
@@ -104,7 +104,7 @@ $objects = $client->listObjects($store->getId(), $model->getId(), 'document', 'v
 
 See [docs/Queries.md](docs/Queries.md) for more information.
 
-### Streaming objects
+### Streaming Objects
 
 ```php
 $stream = $client->streamedListObjects(
@@ -125,7 +125,7 @@ $client->writeAssertions($store->getId(), $model->getId(), $assertions);
 
 See [docs/Assertions.md](docs/Assertions.md) for more information.
 
-## DSL transformer
+## DSL Transformer
 
 Use the DSL transformer to parse a DSL schema string into an authorization model and render it back to a DSL string.
 

--- a/docs/API/Client.md
+++ b/docs/API/Client.md
@@ -12,7 +12,7 @@
 
 
 ```php
-public function check([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?bool $trace = null, ?object $context = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [CheckResponseInterface](Responses/CheckResponseInterface.md)
+public function check([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?bool $trace = NULL, ?object $context = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [CheckResponseInterface](Responses/CheckResponseInterface.md)
 ```
 
 Checks if a user has a specific relationship with an object.
@@ -35,7 +35,7 @@ Checks if a user has a specific relationship with an object.
 
 
 ```php
-public function createAuthorizationModel([StoreInterface](Models/StoreInterface.md)|string $store, [TypeDefinitionsInterface](Models/Collections/TypeDefinitionsInterface.md) $typeDefinitions, [ConditionsInterface](Models/Collections/ConditionsInterface.md) $conditions, SchemaVersion $schemaVersion = &quot;1.1&quot;): [CreateAuthorizationModelResponseInterface](Responses/CreateAuthorizationModelResponseInterface.md)
+public function createAuthorizationModel([StoreInterface](Models/StoreInterface.md)|string $store, [TypeDefinitionsInterface](Models/Collections/TypeDefinitionsInterface.md) $typeDefinitions, [ConditionsInterface](Models/Collections/ConditionsInterface.md) $conditions, SchemaVersion $schemaVersion = \OpenFGA\Models\Enums\SchemaVersion::V1_1): [CreateAuthorizationModelResponseInterface](Responses/CreateAuthorizationModelResponseInterface.md)
 ```
 
 Creates a new authorization model with the given type definitions and conditions.
@@ -89,7 +89,7 @@ Deletes a store.
 
 
 ```php
-public function expand([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?[AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string|null $model = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [ExpandResponseInterface](Responses/ExpandResponseInterface.md)
+public function expand([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?[AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string|null $model = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [ExpandResponseInterface](Responses/ExpandResponseInterface.md)
 ```
 
 Expands a relationship tuple to show all users that have the relationship.
@@ -171,7 +171,7 @@ Retrieves store details by ID.
 
 
 ```php
-public function listAuthorizationModels([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = null, ?int $pageSize = null): [ListAuthorizationModelsResponseInterface](Responses/ListAuthorizationModelsResponseInterface.md)
+public function listAuthorizationModels([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = NULL, ?int $pageSize = NULL): [ListAuthorizationModelsResponseInterface](Responses/ListAuthorizationModelsResponseInterface.md)
 ```
 
 Lists authorization models in a store with pagination.
@@ -190,7 +190,7 @@ Lists authorization models in a store with pagination.
 
 
 ```php
-public function listObjects([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $type, string $relation, string $user, ?object $context = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [ListObjectsResponseInterface](Responses/ListObjectsResponseInterface.md)
+public function listObjects([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $type, string $relation, string $user, ?object $context = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [ListObjectsResponseInterface](Responses/ListObjectsResponseInterface.md)
 ```
 
 Lists objects that have a specific relationship with a user.
@@ -214,7 +214,7 @@ Lists objects that have a specific relationship with a user.
 
 
 ```php
-public function listStores(?string $continuationToken = null, ?int $pageSize = null): [ListStoresResponseInterface](Responses/ListStoresResponseInterface.md)
+public function listStores(?string $continuationToken = NULL, ?int $pageSize = NULL): [ListStoresResponseInterface](Responses/ListStoresResponseInterface.md)
 ```
 
 Lists all stores with pagination.
@@ -232,7 +232,7 @@ Lists all stores with pagination.
 
 
 ```php
-public function listTupleChanges([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = null, ?int $pageSize = null, ?string $type = null, ?DateTimeImmutable $startTime = null): [ListTupleChangesResponseInterface](Responses/ListTupleChangesResponseInterface.md)
+public function listTupleChanges([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = NULL, ?int $pageSize = NULL, ?string $type = NULL, ?DateTimeImmutable $startTime = NULL): [ListTupleChangesResponseInterface](Responses/ListTupleChangesResponseInterface.md)
 ```
 
 Lists changes to relationship tuples in a store.
@@ -253,7 +253,7 @@ Lists changes to relationship tuples in a store.
 
 
 ```php
-public function listUsers([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $object, string $relation, [UserTypeFiltersInterface](Models/Collections/UserTypeFiltersInterface.md) $userFilters, ?object $context = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [ListUsersResponseInterface](Responses/ListUsersResponseInterface.md)
+public function listUsers([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $object, string $relation, [UserTypeFiltersInterface](Models/Collections/UserTypeFiltersInterface.md) $userFilters, ?object $context = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [ListUsersResponseInterface](Responses/ListUsersResponseInterface.md)
 ```
 
 Lists users that have a specific relationship with an object.
@@ -295,7 +295,7 @@ Retrieves assertions for an authorization model.
 
 
 ```php
-public function readTuples([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?string $continuationToken = null, ?int $pageSize = null, ?Consistency $consistency = null): [ReadTuplesResponseInterface](Responses/ReadTuplesResponseInterface.md)
+public function readTuples([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?string $continuationToken = NULL, ?int $pageSize = NULL, ?Consistency $consistency = NULL): [ReadTuplesResponseInterface](Responses/ReadTuplesResponseInterface.md)
 ```
 
 Reads relationship tuples from a store with optional filtering and pagination.
@@ -335,7 +335,7 @@ Creates or updates assertions for an authorization model.
 
 
 ```php
-public function writeTuples([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $writes = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $deletes = null): [WriteTuplesResponseInterface](Responses/WriteTuplesResponseInterface.md)
+public function writeTuples([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $writes = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $deletes = NULL): [WriteTuplesResponseInterface](Responses/WriteTuplesResponseInterface.md)
 ```
 
 Writes or deletes relationship tuples in a store.

--- a/docs/API/ClientInterface.md
+++ b/docs/API/ClientInterface.md
@@ -10,7 +10,7 @@
 
 
 ```php
-public function check([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?bool $trace = null, ?object $context = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [CheckResponseInterface](Responses/CheckResponseInterface.md)
+public function check([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?bool $trace = NULL, ?object $context = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [CheckResponseInterface](Responses/CheckResponseInterface.md)
 ```
 
 Checks if a user has a specific relationship with an object.
@@ -33,7 +33,7 @@ Checks if a user has a specific relationship with an object.
 
 
 ```php
-public function createAuthorizationModel([StoreInterface](Models/StoreInterface.md)|string $store, [TypeDefinitionsInterface](Models/Collections/TypeDefinitionsInterface.md) $typeDefinitions, [ConditionsInterface](Models/Collections/ConditionsInterface.md) $conditions, SchemaVersion $schemaVersion = &quot;1.1&quot;): [CreateAuthorizationModelResponseInterface](Responses/CreateAuthorizationModelResponseInterface.md)
+public function createAuthorizationModel([StoreInterface](Models/StoreInterface.md)|string $store, [TypeDefinitionsInterface](Models/Collections/TypeDefinitionsInterface.md) $typeDefinitions, [ConditionsInterface](Models/Collections/ConditionsInterface.md) $conditions, SchemaVersion $schemaVersion = \OpenFGA\Models\Enums\SchemaVersion::V1_1): [CreateAuthorizationModelResponseInterface](Responses/CreateAuthorizationModelResponseInterface.md)
 ```
 
 Creates a new authorization model with the given type definitions and conditions.
@@ -87,7 +87,7 @@ Deletes a store.
 
 
 ```php
-public function expand([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?[AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string|null $model = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [ExpandResponseInterface](Responses/ExpandResponseInterface.md)
+public function expand([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?[AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string|null $model = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [ExpandResponseInterface](Responses/ExpandResponseInterface.md)
 ```
 
 Expands a relationship tuple to show all users that have the relationship.
@@ -169,7 +169,7 @@ Retrieves store details by ID.
 
 
 ```php
-public function listAuthorizationModels([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = null, ?int $pageSize = null): [ListAuthorizationModelsResponseInterface](Responses/ListAuthorizationModelsResponseInterface.md)
+public function listAuthorizationModels([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = NULL, ?int $pageSize = NULL): [ListAuthorizationModelsResponseInterface](Responses/ListAuthorizationModelsResponseInterface.md)
 ```
 
 Lists authorization models in a store with pagination.
@@ -188,7 +188,7 @@ Lists authorization models in a store with pagination.
 
 
 ```php
-public function listObjects([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $type, string $relation, string $user, ?object $context = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [ListObjectsResponseInterface](Responses/ListObjectsResponseInterface.md)
+public function listObjects([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $type, string $relation, string $user, ?object $context = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [ListObjectsResponseInterface](Responses/ListObjectsResponseInterface.md)
 ```
 
 Lists objects that have a specific relationship with a user.
@@ -212,7 +212,7 @@ Lists objects that have a specific relationship with a user.
 
 
 ```php
-public function listStores(?string $continuationToken = null, ?int $pageSize = null): [ListStoresResponseInterface](Responses/ListStoresResponseInterface.md)
+public function listStores(?string $continuationToken = NULL, ?int $pageSize = NULL): [ListStoresResponseInterface](Responses/ListStoresResponseInterface.md)
 ```
 
 Lists all stores with pagination.
@@ -230,7 +230,7 @@ Lists all stores with pagination.
 
 
 ```php
-public function listTupleChanges([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = null, ?int $pageSize = null, ?string $type = null, ?DateTimeImmutable $startTime = null): [ListTupleChangesResponseInterface](Responses/ListTupleChangesResponseInterface.md)
+public function listTupleChanges([StoreInterface](Models/StoreInterface.md)|string $store, ?string $continuationToken = NULL, ?int $pageSize = NULL, ?string $type = NULL, ?DateTimeImmutable $startTime = NULL): [ListTupleChangesResponseInterface](Responses/ListTupleChangesResponseInterface.md)
 ```
 
 Lists changes to relationship tuples in a store.
@@ -251,7 +251,7 @@ Lists changes to relationship tuples in a store.
 
 
 ```php
-public function listUsers([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $object, string $relation, [UserTypeFiltersInterface](Models/Collections/UserTypeFiltersInterface.md) $userFilters, ?object $context = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = null, ?Consistency $consistency = null): [ListUsersResponseInterface](Responses/ListUsersResponseInterface.md)
+public function listUsers([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, string $object, string $relation, [UserTypeFiltersInterface](Models/Collections/UserTypeFiltersInterface.md) $userFilters, ?object $context = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $contextualTuples = NULL, ?Consistency $consistency = NULL): [ListUsersResponseInterface](Responses/ListUsersResponseInterface.md)
 ```
 
 Lists users that have a specific relationship with an object.
@@ -293,7 +293,7 @@ Retrieves assertions for an authorization model.
 
 
 ```php
-public function readTuples([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?string $continuationToken = null, ?int $pageSize = null, ?Consistency $consistency = null): [ReadTuplesResponseInterface](Responses/ReadTuplesResponseInterface.md)
+public function readTuples([StoreInterface](Models/StoreInterface.md)|string $store, [TupleKeyInterface](Models/TupleKeyInterface.md) $tupleKey, ?string $continuationToken = NULL, ?int $pageSize = NULL, ?Consistency $consistency = NULL): [ReadTuplesResponseInterface](Responses/ReadTuplesResponseInterface.md)
 ```
 
 Reads relationship tuples from a store with optional filtering and pagination.
@@ -333,7 +333,7 @@ Creates or updates assertions for an authorization model.
 
 
 ```php
-public function writeTuples([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $writes = null, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $deletes = null): [WriteTuplesResponseInterface](Responses/WriteTuplesResponseInterface.md)
+public function writeTuples([StoreInterface](Models/StoreInterface.md)|string $store, [AuthorizationModelInterface](Models/AuthorizationModelInterface.md)|string $model, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $writes = NULL, ?[TupleKeysInterface](Models/Collections/TupleKeysInterface.md) $deletes = NULL): [WriteTuplesResponseInterface](Responses/WriteTuplesResponseInterface.md)
 ```
 
 Writes or deletes relationship tuples in a store.

--- a/docs/API/Models/Collections/Assertions.md
+++ b/docs/API/Models/Collections/Assertions.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/AssertionsInterface.md
+++ b/docs/API/Models/Collections/AssertionsInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/AuthorizationModels.md
+++ b/docs/API/Models/Collections/AuthorizationModels.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/AuthorizationModelsInterface.md
+++ b/docs/API/Models/Collections/AuthorizationModelsInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/Computeds.md
+++ b/docs/API/Models/Collections/Computeds.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/ComputedsInterface.md
+++ b/docs/API/Models/Collections/ComputedsInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/ConditionParameters.md
+++ b/docs/API/Models/Collections/ConditionParameters.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/ConditionParametersInterface.md
+++ b/docs/API/Models/Collections/ConditionParametersInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/Conditions.md
+++ b/docs/API/Models/Collections/Conditions.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/ConditionsInterface.md
+++ b/docs/API/Models/Collections/ConditionsInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/IndexedCollectionInterface.md
+++ b/docs/API/Models/Collections/IndexedCollectionInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/Nodes.md
+++ b/docs/API/Models/Collections/Nodes.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/NodesInterface.md
+++ b/docs/API/Models/Collections/NodesInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/Stores.md
+++ b/docs/API/Models/Collections/Stores.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/StoresInterface.md
+++ b/docs/API/Models/Collections/StoresInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/TupleChanges.md
+++ b/docs/API/Models/Collections/TupleChanges.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/TupleChangesInterface.md
+++ b/docs/API/Models/Collections/TupleChangesInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/TupleKeys.md
+++ b/docs/API/Models/Collections/TupleKeys.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/TupleKeysInterface.md
+++ b/docs/API/Models/Collections/TupleKeysInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/Tuples.md
+++ b/docs/API/Models/Collections/Tuples.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/TuplesInterface.md
+++ b/docs/API/Models/Collections/TuplesInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/TypeDefinitions.md
+++ b/docs/API/Models/Collections/TypeDefinitions.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/TypeDefinitionsInterface.md
+++ b/docs/API/Models/Collections/TypeDefinitionsInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/UserTypeFilters.md
+++ b/docs/API/Models/Collections/UserTypeFilters.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/UserTypeFiltersInterface.md
+++ b/docs/API/Models/Collections/UserTypeFiltersInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/Users.md
+++ b/docs/API/Models/Collections/Users.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/UsersInterface.md
+++ b/docs/API/Models/Collections/UsersInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/UsersList.md
+++ b/docs/API/Models/Collections/UsersList.md
@@ -104,7 +104,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Models/Collections/UsersListInterface.md
+++ b/docs/API/Models/Collections/UsersListInterface.md
@@ -103,7 +103,7 @@ Filters the collection using a callback.
 
 
 ```php
-public function first(?callable $callback = null)
+public function first(?callable $callback = NULL)
 ```
 
 Returns the first item that matches the callback.

--- a/docs/API/Schema/SchemaBuilder.md
+++ b/docs/API/Schema/SchemaBuilder.md
@@ -10,7 +10,7 @@
 
 
 ```php
-public function array(string $name, array $items, bool $required = false, mixed $default = null): self
+public function array(string $name, array $items, bool $required = false, mixed $default = NULL): self
 ```
 
 Add an array property.
@@ -30,7 +30,7 @@ Add an array property.
 
 
 ```php
-public function boolean(string $name, bool $required = false, mixed $default = null): self
+public function boolean(string $name, bool $required = false, mixed $default = NULL): self
 ```
 
 Add a boolean property.
@@ -49,7 +49,7 @@ Add a boolean property.
 
 
 ```php
-public function date(string $name, bool $required = false, mixed $default = null): self
+public function date(string $name, bool $required = false, mixed $default = NULL): self
 ```
 
 Add a date property.
@@ -68,7 +68,7 @@ Add a date property.
 
 
 ```php
-public function datetime(string $name, bool $required = false, mixed $default = null): self
+public function datetime(string $name, bool $required = false, mixed $default = NULL): self
 ```
 
 Add a datetime property.
@@ -87,7 +87,7 @@ Add a datetime property.
 
 
 ```php
-public function integer(string $name, bool $required = false, mixed $default = null): self
+public function integer(string $name, bool $required = false, mixed $default = NULL): self
 ```
 
 Add an integer property.
@@ -106,7 +106,7 @@ Add an integer property.
 
 
 ```php
-public function number(string $name, bool $required = false, mixed $default = null): self
+public function number(string $name, bool $required = false, mixed $default = NULL): self
 ```
 
 Add a number (float) property.
@@ -157,7 +157,7 @@ Build and register the schema.
 
 
 ```php
-public function string(string $name, bool $required = false, ?string $format = null, ?array $enum = null, mixed $default = null): self
+public function string(string $name, bool $required = false, ?string $format = NULL, ?array $enum = NULL, mixed $default = NULL): self
 ```
 
 Add a string property.

--- a/docs/AuthorizationModels.md
+++ b/docs/AuthorizationModels.md
@@ -1,4 +1,4 @@
-# Authorization models
+# Authorization Models
 
 Create and retrieve authorization models.
 

--- a/docs/DslTransformer.md
+++ b/docs/DslTransformer.md
@@ -1,0 +1,33 @@
+# DSL transformer
+
+Transform DSL strings to authorization models and back.
+
+```php
+use OpenFGA\Language\DslTransformer;
+use OpenFGA\Schema\SchemaValidator;
+
+$dsl = <<'DSL'
+model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: self
+DSL;
+
+$validator = new SchemaValidator();
+$validator
+    ->registerSchema(OpenFGA\Models\AuthorizationModel::schema())
+    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitions::schema())
+    ->registerSchema(OpenFGA\Models\TypeDefinition::schema())
+    ->registerSchema(OpenFGA\Models\Collections\TypeDefinitionRelations::schema())
+    ->registerSchema(OpenFGA\Models\Userset::schema())
+    ->registerSchema(OpenFGA\Models\Collections\Usersets::schema())
+    ->registerSchema(OpenFGA\Models\ObjectRelation::schema());
+
+$model = DslTransformer::fromDsl($dsl, $validator);
+
+$dslString = DslTransformer::toDsl($model);
+```

--- a/docs/DslTransformer.md
+++ b/docs/DslTransformer.md
@@ -1,4 +1,4 @@
-# DSL transformer
+# DSL Transformer
 
 Transform DSL strings to authorization models and back.
 

--- a/docs/Queries.md
+++ b/docs/Queries.md
@@ -1,4 +1,4 @@
-# Relationship queries
+# Relationship Queries
 
 Check and expand relationships or list matching objects and users.
 

--- a/docs/RelationshipTuples.md
+++ b/docs/RelationshipTuples.md
@@ -1,4 +1,4 @@
-# Relationship tuples
+# Relationship Tuples
 
 Write, read and track relationship tuples.
 


### PR DESCRIPTION
## Summary
- include DSL transformer instructions in README
- document the DslTransformer class

## Testing
- `pre-commit` *(skipped: documentation changes)*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
	- Added a new section to the README demonstrating usage of the DSL transformer in PHP, including code examples and a reference to further documentation.
	- Introduced a dedicated documentation file detailing the DSL transformer’s functionality, usage examples, and integration with schema validation.
	- Updated the README’s documentation section with a link to the new DSL transformer documentation.
	- Standardized PHP method signature documentation by updating default nullable parameter values from `null` to `NULL` and replaced schema version string with a constant for consistency across client API docs.
	- Applied stylistic updates to method signatures in multiple collections and schema builder documentation, changing default nullable parameters from lowercase `null` to uppercase `NULL`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->