### PR TITLE
fix(access-token): expire token at scheduled time

### DIFF
--- a/src/Authentication/AccessToken.php
+++ b/src/Authentication/AccessToken.php
@@ -142,7 +142,7 @@ final readonly class AccessToken implements AccessTokenInterface
     #[Override]
     public function isExpired(): bool
     {
-        return $this->expires < time();
+        return $this->expires <= time();
     }
 
     /**

--- a/tests/Unit/Authentication/AccessTokenTest.php
+++ b/tests/Unit/Authentication/AccessTokenTest.php
@@ -93,12 +93,12 @@ describe('AccessToken', function (): void {
         $currentTime = time();
         $token = new AccessToken('token', $currentTime);
 
-        // At exact expiration time, token is expired (expires < time())
-        expect($token->isExpired())->toBeFalse();
+        // At exact expiration time the token should be considered expired
+        expect($token->isExpired())->toBeTrue();
 
-        // One second past expiration, token should be expired
-        $expiredToken = new AccessToken('token', $currentTime - 1);
-        expect($expiredToken->isExpired())->toBeTrue();
+        // One second before expiration the token is still valid
+        $validToken = new AccessToken('token', $currentTime + 1);
+        expect($validToken->isExpired())->toBeFalse();
     });
 
     test('fromResponse parses valid response', function (): void {


### PR DESCRIPTION
## Summary
- consider token expired when current time reaches expiry
- update AccessToken expiration test expectations

## Testing
- `composer lint` *(fails: command not found)*
- `composer test:unit:no-coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847ba1fd36c832f8d5634710b306b90

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated token expiration logic to consider tokens expired exactly at their expiration time, ensuring more accurate authentication behavior.

- **Tests**
  - Adjusted tests to verify the updated token expiration behavior at boundary times.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->