### PR TITLE
fix: align early stop executor parameter name

### DIFF
--- a/src/Network/ConcurrentExecutorInterface.php
+++ b/src/Network/ConcurrentExecutorInterface.php
@@ -25,14 +25,15 @@ interface ConcurrentExecutorInterface
      *
      * @template T
      *
-     * @param array<int, callable(): T> $tasks         Array of callables to execute
-     * @param int                       $maxConcurrent Maximum number of concurrent executions
+     * @param array<int, callable(): T> $tasks            Array of callables to execute
+     * @param int                       $maxConcurrent    Maximum number of concurrent executions
+     * @param bool                      $stopOnFirstError Stop all tasks when first error is encountered
      *
      * @throws Throwable If any task fails and error handling is not configured
      *
      * @return array<int, T|Throwable> Array of results or exceptions in the same order as tasks
      */
-    public function executeParallel(array $tasks, int $maxConcurrent = 10): array;
+    public function executeParallel(array $tasks, int $maxConcurrent = 10, bool $stopOnFirstError = false): array;
 
     /**
      * Get the maximum recommended concurrency for the current environment.

--- a/tests/Unit/Network/RequestManagerTest.php
+++ b/tests/Unit/Network/RequestManagerTest.php
@@ -9,6 +9,7 @@ use OpenFGA\Client;
 use OpenFGA\Exceptions\{NetworkException};
 use OpenFGA\Network\{RequestContext, RequestManager, RequestMethod};
 use OpenFGA\Requests\RequestInterface as ClientRequestInterface;
+use OpenFGA\Results\{Failure, FailureInterface, Success, SuccessInterface};
 use PHPUnit\Framework\MockObject\MockObject;
 use Psr\Http\Client\ClientInterface;
 use Psr\Http\Message\{RequestFactoryInterface, RequestInterface, ResponseFactoryInterface, ResponseInterface, StreamFactoryInterface, StreamInterface};
@@ -330,5 +331,288 @@ describe('RequestManager', function (): void {
         $result = $manager->request($clientRequest);
 
         expect($result)->toBe($psrRequest);
+    });
+
+    describe('executeParallel', function (): void {
+        test('executes single task sequentially', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $task = fn () => new Success('result');
+            $results = $manager->executeParallel([$task], 1, false);
+
+            expect($results)->toHaveCount(1);
+            expect($results[0])->toBeInstanceOf(SuccessInterface::class);
+            expect($results[0]->unwrap())->toBe('result');
+        });
+
+        test('executes multiple tasks with parallelism limit', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $tasks = [
+                fn () => new Success('result1'),
+                fn () => new Success('result2'),
+                fn () => new Success('result3'),
+                fn () => new Success('result4'),
+            ];
+
+            $results = $manager->executeParallel($tasks, 2, false);
+
+            expect($results)->toHaveCount(4);
+            expect($results[0]->unwrap())->toBe('result1');
+            expect($results[1]->unwrap())->toBe('result2');
+            expect($results[2]->unwrap())->toBe('result3');
+            expect($results[3]->unwrap())->toBe('result4');
+        });
+
+        test('handles empty task array', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $results = $manager->executeParallel([], 5, false);
+
+            expect($results)->toBeEmpty();
+        });
+
+        test('preserves task order in results', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $tasks = [];
+
+            for ($i = 0; 10 > $i; $i++) {
+                $tasks[] = fn () => new Success("result{$i}");
+            }
+
+            $results = $manager->executeParallel($tasks, 3, false);
+
+            expect($results)->toHaveCount(10);
+
+            for ($i = 0; 10 > $i; $i++) {
+                expect($results[$i]->unwrap())->toBe("result{$i}");
+            }
+        });
+
+        test('handles task exceptions gracefully', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $tasks = [
+                fn () => new Success('success'),
+                fn () => new Failure(new Exception('test error')),
+                fn () => new Success('success2'),
+            ];
+
+            $results = $manager->executeParallel($tasks, 2, false);
+
+            expect($results)->toHaveCount(3);
+            expect($results[0])->toBeInstanceOf(SuccessInterface::class);
+            expect($results[1])->toBeInstanceOf(FailureInterface::class);
+            expect($results[2])->toBeInstanceOf(SuccessInterface::class);
+        });
+
+        test('respects maxParallelRequests parameter correctly', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $startTime = microtime(true);
+            $executionTimes = [];
+
+            $tasks = [];
+
+            for ($i = 0; 6 > $i; $i++) {
+                $tasks[] = function () use (&$executionTimes, $startTime): SuccessInterface {
+                    $executionTimes[] = microtime(true) - $startTime;
+                    usleep(1000); // 1ms delay for faster tests
+
+                    return new Success('result');
+                };
+            }
+
+            $results = $manager->executeParallel($tasks, 3, false);
+
+            expect($results)->toHaveCount(6);
+            expect($executionTimes)->toHaveCount(6);
+        });
+
+        test('stops early on first error when stopOnFirstError is true', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $executedTasks = [];
+            $tasks = [
+                function () use (&$executedTasks): SuccessInterface {
+                    $executedTasks[] = 'task1';
+
+                    return new Success('result1');
+                },
+                function () use (&$executedTasks): FailureInterface {
+                    $executedTasks[] = 'task2_error';
+
+                    return new Failure(new Exception('Early stop error'));
+                },
+                function () use (&$executedTasks): SuccessInterface {
+                    $executedTasks[] = 'task3';
+
+                    return new Success('result3');
+                },
+                function () use (&$executedTasks): SuccessInterface {
+                    $executedTasks[] = 'task4';
+
+                    return new Success('result4');
+                },
+            ];
+
+            // Force sequential execution by using maxParallelRequests of 1
+            // This ensures stopOnFirstError behavior is testable
+            $results = $manager->executeParallel($tasks, 1, true);
+
+            // Should have stopped early, so only first two tasks execute
+            expect($results)->toHaveCount(2);
+            expect($results[0])->toBeInstanceOf(SuccessInterface::class);
+            expect($results[1])->toBeInstanceOf(FailureInterface::class);
+
+            // Verify the correct tasks were executed
+            expect($executedTasks)->toContain('task1');
+            expect($executedTasks)->toContain('task2_error');
+            expect($executedTasks)->not->toContain('task3');
+            expect($executedTasks)->not->toContain('task4');
+        });
+
+        test('continues execution when stopOnFirstError is false', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $tasks = [
+                fn () => new Success('result1'),
+                fn () => new Failure(new Exception('Mid error')),
+                fn () => new Success('result3'),
+                fn () => new Failure(new Exception('Another error')),
+                fn () => new Success('result5'),
+            ];
+
+            $results = $manager->executeParallel($tasks, 2, false);
+
+            expect($results)->toHaveCount(5);
+            expect($results[0])->toBeInstanceOf(SuccessInterface::class);
+            expect($results[1])->toBeInstanceOf(FailureInterface::class);
+            expect($results[2])->toBeInstanceOf(SuccessInterface::class);
+            expect($results[3])->toBeInstanceOf(FailureInterface::class);
+            expect($results[4])->toBeInstanceOf(SuccessInterface::class);
+        });
+
+        test('tests concurrent execution with no errors', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $executionOrder = [];
+            $tasks = [
+                function () use (&$executionOrder): SuccessInterface {
+                    $executionOrder[] = 'task1';
+
+                    return new Success('result1');
+                },
+                function () use (&$executionOrder): SuccessInterface {
+                    $executionOrder[] = 'task2';
+
+                    return new Success('result2');
+                },
+                function () use (&$executionOrder): SuccessInterface {
+                    $executionOrder[] = 'task3';
+
+                    return new Success('result3');
+                },
+            ];
+
+            $results = $manager->executeParallel($tasks, 2, false);
+
+            expect($results)->toHaveCount(3);
+            expect($results[0]->unwrap())->toBe('result1');
+            expect($results[1]->unwrap())->toBe('result2');
+            expect($results[2]->unwrap())->toBe('result3');
+
+            // All tasks should have executed
+            expect($executionOrder)->toContain('task1');
+            expect($executionOrder)->toContain('task2');
+            expect($executionOrder)->toContain('task3');
+        });
+
+        test('handles edge case with zero maxParallelRequests', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $tasks = [
+                fn () => new Success('result1'),
+                fn () => new Success('result2'),
+            ];
+
+            // Should fallback to sequential execution
+            $results = $manager->executeParallel($tasks, 0, false);
+
+            expect($results)->toHaveCount(2);
+            expect($results[0]->unwrap())->toBe('result1');
+            expect($results[1]->unwrap())->toBe('result2');
+        });
+
+        test('handles edge case with negative maxParallelRequests', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $tasks = [
+                fn () => new Success('result1'),
+                fn () => new Success('result2'),
+            ];
+
+            // Should fallback to sequential execution
+            $results = $manager->executeParallel($tasks, -1, false);
+
+            expect($results)->toHaveCount(2);
+            expect($results[0]->unwrap())->toBe('result1');
+            expect($results[1]->unwrap())->toBe('result2');
+        });
+
+        test('handles large maxParallelRequests value correctly', function (): void {
+            $manager = new RequestManager(
+                url: 'https://api.example.com',
+                maxRetries: 3,
+            );
+
+            $tasks = [
+                fn () => new Success('result1'),
+                fn () => new Success('result2'),
+                fn () => new Success('result3'),
+            ];
+
+            // maxParallelRequests larger than task count
+            $results = $manager->executeParallel($tasks, 100, false);
+
+            expect($results)->toHaveCount(3);
+            expect($results[0]->unwrap())->toBe('result1');
+            expect($results[1]->unwrap())->toBe('result2');
+            expect($results[2]->unwrap())->toBe('result3');
+        });
     });
 });


### PR DESCRIPTION
## Summary
- clean up the parameter name in `RequestManager::executeConcurrentWithEarlyStop`

## Testing
- `composer test:unit:no-coverage`
- `composer lint`


------
https://chatgpt.com/codex/tasks/task_e_684a51750b14832f955319d1c1a8284a

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Enhanced parallel task execution to support early stopping on errors, improving reliability and control.
  - Removed internal concurrency implementation in favor of a unified external executor handling parallelism and error stopping.
- **Tests**
  - Added extensive tests covering parallel execution scenarios, error handling, early termination, and concurrency limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->